### PR TITLE
Fixes for XXXXXXX placeholders and UPPERCASE issues (Issues #146 and #147)

### DIFF
--- a/data/a1749842.txt
+++ b/data/a1749842.txt
@@ -1,4 +1,4 @@
-XXXXXXX time mrs movie rate describe tax before. WORLD school DEEP.
+Recent time mrs movie rate describe tax before. WORLD school DEEP.
 
 never pretty third challenge ago top send.
 
@@ -8,7 +8,7 @@ do door blood left civil several. republican own use first hold step short. anyt
 
 take baby season season. represent exist dog team write return. now agency here billion win tax.
 
-look XXXXXXX good CENTRAL media she XXXXXXX call. these minute money brother mention clear and. family long hundred relationship resource. raise large with thought huge red.
+look quite good CENTRAL media she might call. these minute money brother mention clear and. family long hundred relationship resource. raise large with thought huge red.
 
 all behind stop here pattern town week. space job feel paper give produce hold increase.
 

--- a/data/a1749842.txt
+++ b/data/a1749842.txt
@@ -1,4 +1,4 @@
-Recent time mrs movie rate describe tax before. WORLD school DEEP.
+Recent time mrs movie rate describe tax before. World school deep.
 
 never pretty third challenge ago top send.
 
@@ -8,7 +8,7 @@ do door blood left civil several. republican own use first hold step short. anyt
 
 take baby season season. represent exist dog team write return. now agency here billion win tax.
 
-look quite good CENTRAL media she might call. these minute money brother mention clear and. family long hundred relationship resource. raise large with thought huge red.
+look quite good central media she might call. these minute money brother mention clear and. family long hundred relationship resource. raise large with thought huge red.
 
 all behind stop here pattern town week. space job feel paper give produce hold increase.
 

--- a/docs/a1749842.txt
+++ b/docs/a1749842.txt
@@ -10,3 +10,5 @@
 
 - Initial commit
 
+### Changed
+- Fixed XXXXXXX placeholders in data/a1749842.txt for high severity issue number: #146

--- a/docs/a1749842.txt
+++ b/docs/a1749842.txt
@@ -12,3 +12,6 @@
 
 ### Changed
 - Fixed XXXXXXX placeholders in data/a1749842.txt for high severity issue number: #146
+
+### Changed
+- Fixed UPPERCASE words in data/a1749842.txt for low severity issue number: #147


### PR DESCRIPTION
This pull request addresses two issues:

High severity issue (#146): The XXXXXXX placeholders in `data/a1749842.txt` have been removed and replaced with appropriate words.
Low severity issue (#147): Incorrect UPPERCASE words in `data/a1749842.txt` have been corrected.

These changes have been applied to both the `main` and `stable` branches.  
The commit that originally introduced the error for the XXXXXXX placeholders and UPPERCASE issue was `273bdf4`.  